### PR TITLE
Fix cgroup memory enable and dashboard configuration URL

### DIFF
--- a/roles/common/files/cmdline.txt
+++ b/roles/common/files/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_enable=memory
+dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_memory=1


### PR DESCRIPTION
These are set of fixes that were required for me to reproduce your results on a Raspberry Pi/Kubernetes cluster of 4 nodes:

- Update mechanism to enable cgroup memory
- Fix dashboard configuration URL

Thanks for taking the time to codify these steps. Really helped speed up the process of getting a cluster up-and-running.