### PR TITLE
Set hostname to what is in the inventory.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+- name: Ensure hostname set
+  hostname: name={{ inventory_hostname }}
+  when: not inventory_hostname|match('(\d{1,3}\.){3}\d{1,3}')
+  tags:
+    - hostname
+
+- name: Ensure hostname is in /etc/hosts
+  lineinfile:
+    dest=/etc/hosts
+    regexp="^{{ ansible_default_ipv4.address }}.+$"
+    line="{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+  tags:
+    - hostname
+
 # tasks file for common
 - name: Enabling cgroup options at boot
   copy:


### PR DESCRIPTION
I was setting this up with a stack of new Raspberry Pi and wanted to set the hostname to match my Ansible inventory.

Credit to https://gist.github.com/phips/11233502 for the added commands.