### PR TITLE
why not both?

### DIFF
--- a/roles/common/files/cmdline.txt
+++ b/roles/common/files/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_memory=1
+dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory


### PR DESCRIPTION
I found the elimination of cgroup_enable=memory actually broke my raspbian kubernetes setup. putting both worked with my testing after reboot.