### PR TITLE
Updating cmdline.txt to enable cgroups

### DIFF
--- a/roles/common/files/cmdline.txt
+++ b/roles/common/files/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_memory=1
+dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait cgroup_enable=cpuset cgroup_enable=memory cgroup_memory=1


### PR DESCRIPTION
Enabling cgroups was failing. After some research, adding the option `cgroup_enable=memory` option to `cmdline.txt` allows this to work.