### PR TITLE
Move TASK [Pass bridged IPv4 traffic to iptables' chains] after TASK …

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,12 +11,6 @@
   tags:
     - boot
 
-- name: Pass bridged IPv4 traffic to iptables' chains
-  sysctl:
-    name: net.bridge.bridge-nf-call-iptables
-    value: 1
-    state: present
-
 - name: apt-get update
   apt:
     update_cache=yes

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -17,6 +17,12 @@
   script: files/get-docker.sh
   when: docker_there.stat.exists == False
 
+- name: Pass bridged IPv4 traffic to iptables' chains
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+    state: present
+
 # https://kubernetes.io/docs/setup/independent/install-kubeadm/
 - name: Install apt-transport-https
   apt:


### PR DESCRIPTION
…[kubeadm : Run Docker Install Script] is executed.
  
Prevents playbook failure when bridge-nf-call-iptables was set.
  
## Description
  
When the `cluster.yml` playbook is launched for the first time on a fresh raspbian image it always fails on `TASK [common : Pass bridged IPv4 traffic to iptables' chains]`, due to the fact that the path `/proc/sys/net/bridge/bridge-nf-call-iptables` not yet exists, as you can see below:
```
pi@ansible-host ~/git/rak8s $ ansible-playbook cluster.yml 

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [node1]
ok: [node2]
ok: [master]

TASK [common : Enabling cgroup options at boot] ********************************
changed: [node1]
changed: [master]
changed: [node2]

TASK [common : Pass bridged IPv4 traffic to iptables' chains] ******************
fatal: [node1]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\n"}
fatal: [master]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\n"}
fatal: [node2]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\n"}

PLAY RECAP *********************************************************************
master                     : ok=2    changed=1    unreachable=0    failed=1   
node1                      : ok=2    changed=1    unreachable=0    failed=1   
node2                      : ok=2    changed=1    unreachable=0    failed=1  
```
I found out that the path `/proc/sys/net/bridge/bridge-nf-call-iptables` will be created by the `TASK [kubeadm : Run Docker Install Script]`, see: https://github.com/rak8s/rak8s/pull/31  
  
So if we move the `TASK [common : Pass bridged IPv4 traffic to iptables' chains]` from the `common role` to the `kubeadm role` and execute it after the `TASK [kubeadm : Run Docker Install Script]`, the command won't return an error.  
  
## Testing
  
Down here the output of the playbook cluster.yml (run on a fresh image), were I moved `TASK [common : Pass bridged IPv4 traffic to iptables' chains]` after `TASK [kubeadm : Run Docker Install Script]` was executed:
```
$ ansible-playbook cluster.yml 

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [testnode]

TASK [common : Enabling cgroup options at boot] ********************************
ok: [testnode]

TASK [common : apt-get update] *************************************************
ok: [testnode]

TASK [common : apt-get upgrade] ************************************************
ok: [testnode]

TASK [common : Reboot] *********************************************************
skipping: [testnode]

TASK [common : Wait for Reboot] ************************************************
skipping: [testnode]

TASK [kubeadm : Disable Swap] **************************************************
changed: [testnode]

TASK [kubeadm : Determine if docker is installed] ******************************
ok: [testnode]

TASK [kubeadm : Run Docker Install Script] *************************************
changed: [testnode]

TASK [kubeadm : Pass bridged IPv4 traffic to iptables' chains] *****************
changed: [testnode]

TASK [kubeadm : Install apt-transport-https] ***********************************
ok: [testnode]

TASK [kubeadm : Add Google Cloud Repo Key] *************************************
changed: [testnode]
 [WARNING]: Consider using get_url or uri module rather than running curl


TASK [kubeadm : Add Kubernetes to Available apt Sources] ***********************
changed: [testnode]

TASK [kubeadm : apt-get update] ************************************************
changed: [testnode]

TASK [kubeadm : Install k8s Y'all] *********************************************
changed: [testnode] => (item=[u'kubelet', u'kubeadm', u'kubectl'])
etc....
```
Note: The `TASK [kubeadm : Pass bridged IPv4 traffic to iptables' chains]` is now processed without an error.
  
## Issue Number
My change fixes issue #30 

See also closed pull request #31 for more back ground. 

