### PR TITLE
Add troubleshooting steps and timing adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If your SSH user on the Raspberry Pis are not the Raspbian default `pi` user mod
 ```
 ansible -m ping all
 ```
-
+This may fail to ping if you have not setup SSH keys and only configured your Pi's with passwords
 ## Deploy, Deploy, Deploy
 
 ```
@@ -100,6 +100,21 @@ kubectl proxy
 
 Then open a web browser and navigate to:
 [http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/)
+
+# Need to Start Over?
+
+Did something go wrong? Nodes fail some process or not joined to the cluster? Break Docker Versions with apt-update? 
+
+Try the process again from the beginning:
+
+```
+ansible-playbook cluster.yml
+```
+Wait for everything to run and then start again with:
+
+```
+ansible-playbook cluster.yml
+```
 
 # Where to Get Help
 

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -41,6 +41,6 @@
     host: "{{ inventory_hostname }}"
     port: 22
     delay: 15
-    timeout: 90
+    timeout: 120
   become: False
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -51,7 +51,7 @@
     host: "{{ inventory_hostname }}"
     port: 22
     delay: 20
-    timeout: 120
+    timeout: 180
   become: False
   when: cmdline or hostname is changed
   tags:


### PR DESCRIPTION
## Description

Added some info on how to restart this process if you accidentally corrupt your cluster by running apt-update or other situations. Also adjusted the timeout parameters to allow for longer times for nodes to reboot and join. 

## Testing

5 node cluster with 1 master node. I was having consistent timeout issues which would cause one of the nodes to fail to reboot in time and would be passed over by the rest of the playbook.

After this failure, I re-ran the playbook and caused my cluster to become unavailable due to existing Docker and Kubeadm installations being updated to incompatible versions by the initial steps of the playbook.

I also tested running the "Troubleshooting" steps I added once I had issues and re-ran the playbook with adjusted timings successfully
