### PR TITLE
Added dashboard token info and retrieval script

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ kubectl proxy
 Then open a web browser and navigate to:
 [http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/)
 
+Note that the recent versions of the dashboard will need role changes or (simpler) for you to download the token from the kubernetes-dashboard service account.
+
+./get-dashboard-token.sh allows you to do this and will write a dashboard-token.txt file to ~/.kube to authenticate with the web interface
+
 # Need to Start Over?
 
 Did something go wrong? Nodes fail some process or not joined to the cluster? Break Docker Versions with apt-update? 

--- a/get-dashboard-token.sh
+++ b/get-dashboard-token.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+TOKEN=$(kubectl -n kube-system describe secret kubernetes-dashboard | awk '$1=="token:"{print $2}')
+
+echo "${TOKEN}" > ~/.kube/dashboard-token.txt


### PR DESCRIPTION
Quick script to allow dev users to download an instance of the dashboard token to ease authentication via web interface

## Description

Dashboard now requires authentication and to avoid adding users / tokens, downloading the kubernetes-dashboard token is the simplest way of doing this.