### PR TITLE
Correction to use the cleanup playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Did something go wrong? Nodes fail some process or not joined to the cluster? Br
 Try the process again from the beginning:
 
 ```
-ansible-playbook cluster.yml
+ansible-playbook cleanup.yml
 ```
 Wait for everything to run and then start again with:
 


### PR DESCRIPTION
Looks like it was a typo. For cleaning up the environment, use the cleanup.yml playbook.

## Description

Use the cleanup.yml playbook for cleaning up the environment.
This is just a typo.
Hopefully, this correction will also update this web-page: 
https://rak8s.io/

## Testing

This is a documentation correction.

## Issue Number
My change fixes issue #<!-- Put the corresponding issue number here -->

