### PR TITLE
Lock docker version to currently installed version when it is installed

### DIFF
--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -16,6 +16,12 @@
 - name: Run Docker {{ docker_ce_version }} Install Script
   script: "files/get-docker.sh {{ docker_ce_version }}"
   when: docker_there.stat.exists == False
+  register: docker_installed
+
+- name: Lock docker version to {{ docker_ce_version}}
+  command: /usr/bin/apt-mark hold docker-ce
+  when: docker_installed.changed
+
 
 - name: Pass bridged IPv4 traffic to iptables' chains
   sysctl:


### PR DESCRIPTION
<!-- Provide a general summary of changes in the Title above-->

## Description

Locks the docker version to the one requested by the user after it is installed. This prevents an interruption to the playbook from upgrading docker during the apt upgrade, and breaking the pre-flight checks for `kubeadm init`.

<!-- Describe your change in detail -->

When docker is installed using the convenience script, use apt-mark to hold the version currently installed.

## Testing

After running cleanup.yml and verifying that docker is removed from the master, ran the cluster.yml playbook again and verified the docker version using `docker --version` on the master. Attempting apt-get update and apt-get upgrade reports docker-ce package is held back. Testing occurred on the master node.

<!-- How have you tested the changes you made? -->
<!-- Describe your tests in detail and the evironment -->
<!-- you tested the changes in. -->

## Issue Number
My change fixes issue #43.

