### PR TITLE
Ignore failing deletion of swap

### DIFF
--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -4,6 +4,7 @@
 # https://gist.github.com/alexellis/fdbc90de7691a1b9edb545c17da2d975
 - name: Disable Swap
   shell: dphys-swapfile swapoff && dphys-swapfile uninstall && update-rc.d dphys-swapfile remove
+  ignore_errors: True
 
 # Docker Convenience Script Can Only Be Run Once
 - name: Determine if docker is installed


### PR DESCRIPTION
<!-- Provide a general summary of changes in the Title above-->

## Description

Due to using hypriot, which doesn't have dphys-swapfile installed by default, the current deletion process fails.  Adding `ignore_errors` fixes this.

## Testing

```
TASK [kubeadm : Disable Swap] **************************************************************************************************************************************************************************************************************************************************
fatal: [rak8s000]: FAILED! => {"changed": true, "cmd": "dphys-swapfile swapoff && dphys-swapfile uninstall && update-rc.d dphys-swapfile remove", "delta": "0:00:00.005302", "end": "2018-12-24 20:35:44.430288", "msg": "non-zero return code", "rc": 127, "start": "2018-12-24 20:35:44.424986", "stderr": "/bin/sh: 1: dphys-swapfile: not found", "stderr_lines": ["/bin/sh: 1: dphys-swapfile: not found"], "stdout": "", "stdout_lines": []}
...ignoring
```

