### PR TITLE
update dashboard url

### DIFF
--- a/roles/dashboard/tasks/main.yml
+++ b/roles/dashboard/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for dashboard
 - name: Install k8s Dashboard
-  shell: kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard-arm.yaml
+  shell: kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard-arm.yaml
 
 - name: Configure Dashboard Access
   shell: kubectl apply -f https://raw.githubusercontent.com/rak8s/rak8s/master/roles/dashboard/files/dashboard-admin.yaml


### PR DESCRIPTION
Fixes dashboard yaml 404. It was moved in [this commit](https://github.com/kubernetes/dashboard/commit/ae56a40961fc46b263d244789d6c4688d6833332#diff-a0ed1ebb3f4da2a985b54b6a2ddc770f)