### PR TITLE
K8S patch and other clean up items

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -18,7 +18,6 @@ retry_files_enabled = False
 become = True
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null
 control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
-control_path_dir = .cp
 pipelining = True

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,7 +1,7 @@
 token: udy29x.ugyyk3tumg27atmr
 podnet: 10.244.0.0/16
 
-kubernetes_package_version: "1.11.4-00"
+kubernetes_package_version: "1.13.1-00"
 # Available versions:
 # 1.10.3-00
 # 1.10.2-00
@@ -12,7 +12,7 @@ kubernetes_package_version: "1.11.4-00"
 # 1.9.6-00
 # 1.9.5-00
 
-kubernetes_version: "v1.11.4"
+kubernetes_version: "v1.13.1"
 # Available versions:
 # v1.10.3
 # v1.10.2
@@ -23,7 +23,7 @@ kubernetes_version: "v1.11.4"
 # v1.9.6
 # v1.9.5
 
-docker_ce_version: "18.04.0~ce~3-0~raspbian"
+docker_ce_version: "18.06.1~ce~3-0~raspbian"
 # Available versions:
 # 18.05.0~ce~3-0~raspbian
 # 18.04.0~ce~3-0~raspbian
@@ -32,10 +32,10 @@ docker_ce_version: "18.04.0~ce~3-0~raspbian"
 # 18.02.0~ce-0~raspbian
 # 18.01.0~ce-0~raspbian
 
-flannel_version: "v0.10.0"
+flannel_version: "master"
 # v0.10.0
 # v0.9.1
 # v0.9.0
 # v0.8.0
 # v0.7.1
-# v0.7.0
+# v0.7.0  

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,8 +1,9 @@
 token: udy29x.ugyyk3tumg27atmr
 podnet: 10.244.0.0/16
 
-kubernetes_package_version: "1.13.1-00"
+kubernetes_package_version: "1.14.1-00"
 # Available versions:
+# 1.13.1-00
 # 1.10.3-00
 # 1.10.2-00
 # 1.10.1-00
@@ -12,7 +13,7 @@ kubernetes_package_version: "1.13.1-00"
 # 1.9.6-00
 # 1.9.5-00
 
-kubernetes_version: "v1.13.1"
+kubernetes_version: "v1.14.1"
 # Available versions:
 # v1.10.3
 # v1.10.2
@@ -23,7 +24,7 @@ kubernetes_version: "v1.13.1"
 # v1.9.6
 # v1.9.5
 
-docker_ce_version: "18.06.1~ce~3-0~raspbian"
+docker_ce_version: "18.06.2~ce~3-0~raspbian"
 # Available versions:
 # 18.05.0~ce~3-0~raspbian
 # 18.04.0~ce~3-0~raspbian

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,11 +30,6 @@
   tags:
     - boot
 
-- name: python-apt dependency
-  shell: apt-get install -y python-apt
-  args:
-    warn: no
-
 - name: apt-get update
   apt:
     update_cache: yes
@@ -46,14 +41,23 @@
   apt:
     upgrade: full
 
-#- name: Reboot (as needed)
-#  reboot:
-#    reboot_timeout: 3600
-#  when: cmdline or timezone or hostname is changed
-#  tags:
-#    - boot
-#    - shutdown
-- name: Reboot Message
-  debug:
-    msg: "A reboot is required but the reboot module is a little wonky. Hopefully someone fixes this soon."
+- name: python-apt dependency
+  shell: apt-get install -y python-apt
+  args:
+    warn: no
+
+- name: Reboot
+  shell: sleep 2 && shutdown -r now "Ansible Reboot"
+  async: 1
+  poll: 0
+  ignore_errors: True
   when: cmdline or timezone or hostname is changed
+
+- name: Wait for Reboot
+  local_action: wait_for
+  args:
+    host: "{{ inventory_hostname }}"
+    port: 22
+    delay: 15
+    timeout: 120
+  become: False

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,17 +19,17 @@
     name: UTC
   register: timezone
 
-- name: gpu mem check
-  shell: cat /boot/config.txt | grep gpu_mem
-  changed_when: false
-  register: gpu_mem_check
+# - name: gpu mem check
+#   shell: cat /boot/config.txt | grep gpu_mem
+#   changed_when: false
+#   register: gpu_mem_check
 
-- name: reduce gpu memory
-  lineinfile:
-    path: /boot/config.txt
-    line: gpu_mem=16
-  register: gpu_mem
-  when: gpu_mem_check.stdout == ""
+# - name: reduce gpu memory
+#   lineinfile:
+#     path: /boot/config.txt
+#     line: gpu_mem=16
+#   register: gpu_mem
+#   when: gpu_mem_check.stdout == ""
 
 - name: Enabling cgroup options at boot
   copy:

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -25,7 +25,6 @@
   command: /usr/bin/apt-mark hold docker-ce
   when: docker_installed.changed
 
-
 - name: Pass bridged IPv4 traffic to iptables' chains
   sysctl:
     name: net.bridge.bridge-nf-call-iptables

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -14,6 +14,8 @@
 
 # https://docs.docker.com/engine/installation/linux/docker-ce/debian/#install-using-the-convenience-script
 - name: Run Docker {{ docker_ce_version }} Install Script
+  environment:
+    APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE: 1
   script: "files/get-docker.sh {{ docker_ce_version }}"
   when: docker_there.stat.exists == False
 
@@ -41,12 +43,6 @@
     owner: root
     group: root
     mode: 0644
-
-- name: apt-get update
-  apt:
-    update_cache: yes
-    autoclean: yes
-    autoremove: yes
 
 - name: Install k8s {{ kubernetes_package_version }} Y'all
   apt:

--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -34,7 +34,7 @@
   register: kubeadm_join
 
 - name: Install Flannel (Networking)
-  shell: "curl -sSL https://rawgit.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml | sed 's/amd64/arm/g' | kubectl create -f -" 
+  shell: "curl -sSL https://rawgit.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml | kubectl create -f -" 
 
 - name: Poke kubelet
   systemd:


### PR DESCRIPTION
<!-- Provide a general summary of changes in the Title above-->

## Description
Updates to rak8s for a new installation on freshly installed b+'s 
Commit notes are pretty lengthy, but here is the synopsis:
1. Updated base k8s version to something that isn't vulnerable.
2. Removed control path setting as it wasn't working on my ubuntu 16.04 vm /shrug
3. Updated some flannel logic
4. moved a few things around in how apt-get is handled.

## Testing
3 new raspberry pi b+'s
1. ran installation -> successful
2. ran cleanup 
3. ran installation again


## Issue Number
My change fixes issue #50 



