### PR TITLE
Fixed error whilst using rak8s with Raspbian Buster

### DIFF
--- a/roles/kubeadm/files/get-docker.sh
+++ b/roles/kubeadm/files/get-docker.sh
@@ -2,11 +2,11 @@
 set -e
 
 # This script is meant for quick & easy install via:
-#   $ curl -fsSL get.docker.com -o get-docker.sh
+#   $ curl -fsSL https://get.docker.com -o get-docker.sh
 #   $ sh get-docker.sh
 #
 # For test builds (ie. release candidates):
-#   $ curl -fsSL test.docker.com -o test-docker.sh
+#   $ curl -fsSL https://test.docker.com -o test-docker.sh
 #   $ sh test-docker.sh
 #
 # NOTE: Make sure to verify the contents of the script
@@ -16,58 +16,28 @@ set -e
 #
 # Git commit from https://github.com/docker/docker-install when
 # the script was uploaded (Should only be modified by upload job):
-SCRIPT_COMMIT_SHA=1d31602
+SCRIPT_COMMIT_SHA="f45d7c11389849ff46a6b4d94e0dd1ffebca32c1"
 
 
-# This value will automatically get changed for:
-#   * edge
+# The channel to install from:
+#   * nightly
 #   * test
-#   * experimental
-DEFAULT_CHANNEL_VALUE="edge"
+#   * stable
+#   * edge (deprecated)
+DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
 	CHANNEL=$DEFAULT_CHANNEL_VALUE
 fi
 
-DOCKERVERSION=$1
+DEFAULT_DOWNLOAD_URL="https://download.docker.com"
+if [ -z "$DOWNLOAD_URL" ]; then
+	DOWNLOAD_URL=$DEFAULT_DOWNLOAD_URL
+fi
 
-DOWNLOAD_URL="https://download.docker.com"
-
-SUPPORT_MAP="
-x86_64-centos-7
-x86_64-fedora-24
-x86_64-fedora-25
-x86_64-fedora-26
-x86_64-fedora-27
-x86_64-debian-wheezy
-x86_64-debian-jessie
-x86_64-debian-stretch
-x86_64-debian-buster
-x86_64-ubuntu-trusty
-x86_64-ubuntu-xenial
-x86_64-ubuntu-zesty
-x86_64-ubuntu-artful
-s390x-ubuntu-xenial
-s390x-ubuntu-zesty
-s390x-ubuntu-artful
-ppc64le-ubuntu-xenial
-ppc64le-ubuntu-zesty
-ppc64le-ubuntu-artful
-aarch64-ubuntu-xenial
-aarch64-ubuntu-zesty
-aarch64-debian-jessie
-aarch64-debian-stretch
-armv6l-raspbian-jessie
-armv7l-raspbian-jessie
-armv6l-raspbian-stretch
-armv7l-raspbian-stretch
-armv7l-debian-jessie
-armv7l-debian-stretch
-armv7l-debian-buster
-armv7l-ubuntu-trusty
-armv7l-ubuntu-xenial
-armv7l-ubuntu-zesty
-armv7l-ubuntu-artful
-"
+DEFAULT_REPO_FILE="docker-ce.repo"
+if [ -z "$REPO_FILE" ]; then
+	REPO_FILE="$DEFAULT_REPO_FILE"
+fi
 
 mirror=''
 DRY_RUN=${DRY_RUN:-}
@@ -106,6 +76,17 @@ is_dry_run() {
 	else
 		return 0
 	fi
+}
+
+deprecation_notice() {
+	distro=$1
+	date=$2
+	echo
+	echo "DEPRECATION WARNING:"
+	echo "    The distribution, $distro, will no longer be supported in this script as of $date."
+	echo "    If you feel this is a mistake please submit an issue at https://github.com/docker/docker-install/issues/new"
+	echo
+	sleep 10
 }
 
 get_distribution() {
@@ -183,18 +164,23 @@ check_forked() {
 			EOF
 		else
 			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
-				# We're Debian and don't even know it!
-				lsb_dist=debian
+				if [ "$lsb_dist" = "osmc" ]; then
+					# OSMC runs Raspbian
+					lsb_dist=raspbian
+				else
+					# We're Debian and don't even know it!
+					lsb_dist=debian
+				fi
 				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 				case "$dist_version" in
+					10)
+						dist_version="buster"
+					;;
 					9)
 						dist_version="stretch"
 					;;
 					8|'Kali Linux 2')
 						dist_version="jessie"
-					;;
-					7)
-						dist_version="wheezy"
 					;;
 				esac
 			fi
@@ -223,11 +209,11 @@ do_install() {
 	echo "# Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
 
 	if command_exists docker; then
-		version="$(docker -v | cut -d ' ' -f3 | cut -d ',' -f1)"
+		docker_version="$(docker -v | cut -d ' ' -f3 | cut -d ',' -f1)"
 		MAJOR_W=1
 		MINOR_W=10
 
-		semverParse "$version"
+		semverParse "$docker_version"
 
 		shouldWarn=0
 		if [ "$major" -lt "$MAJOR_W" ]; then
@@ -308,14 +294,14 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
 				9)
 					dist_version="stretch"
 				;;
 				8)
 					dist_version="jessie"
-				;;
-				7)
-					dist_version="wheezy"
 				;;
 			esac
 		;;
@@ -345,33 +331,17 @@ do_install() {
 	# Check if this is a forked Linux distro
 	check_forked
 
-	# Check if we actually support this configuration
-	if ! echo "$SUPPORT_MAP" | grep "$(uname -m)-$lsb_dist-$dist_version" >/dev/null; then
-		cat >&2 <<-'EOF'
-
-		Either your platform is not easily detectable or is not supported by this
-		installer script.
-		Please visit the following URL for more detailed installation instructions:
-
-		https://docs.docker.com/engine/installation/
-
-		EOF
-		exit 1
-	fi
-
 	# Run setup for each distro accordingly
 	case "$lsb_dist" in
 		ubuntu|debian|raspbian)
 			pre_reqs="apt-transport-https ca-certificates curl"
 			if [ "$lsb_dist" = "debian" ]; then
-				if [ "$dist_version" = "wheezy" ]; then
-					add_debian_backport_repo "$dist_version"
-				fi
 				# libseccomp2 does not exist for debian jessie main repos for aarch64
 				if [ "$(uname -m)" = "aarch64" ] && [ "$dist_version" = "jessie" ]; then
 					add_debian_backport_repo "$dist_version"
 				fi
 			fi
+
 			if ! command -v gpg > /dev/null; then
 				pre_reqs="$pre_reqs gnupg"
 			fi
@@ -381,41 +351,66 @@ do_install() {
 					set -x
 				fi
 				$sh_c 'apt-get update -qq >/dev/null'
-				$sh_c "apt-get install -y -qq $pre_reqs >/dev/null"
+				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
-				if [ "$lsb_dist" = "debian" ] && [ "$dist_version" = "wheezy" ]; then
-					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list.d/docker.list'
-				fi
 				$sh_c 'apt-get update -qq >/dev/null'
-				$sh_c "apt-get install -y -qq --no-install-recommends docker-ce=${DOCKERVERSION} >/dev/null"
+			)
+			pkg_version=""
+			if [ -n "$VERSION" ]; then
+				if is_dry_run; then
+					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+				else
+					# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
+					search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+					pkg_version="$($sh_c "$search_command")"
+					echo "INFO: Searching repository for VERSION '$VERSION'"
+					echo "INFO: $search_command"
+					if [ -z "$pkg_version" ]; then
+						echo
+						echo "ERROR: '$VERSION' not found amongst apt-cache madison results"
+						echo
+						exit 1
+					fi
+					search_command="apt-cache madison 'docker-ce-cli' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+					# Don't insert an = for cli_pkg_version, we'll just include it later
+					cli_pkg_version="$($sh_c "$search_command")"
+					pkg_version="=$pkg_version"
+				fi
+			fi
+			(
+				if ! is_dry_run; then
+					set -x
+				fi
+				if [ -n "$cli_pkg_version" ]; then
+					$sh_c "apt-get install -y -qq --no-install-recommends docker-ce-cli=$cli_pkg_version >/dev/null"
+				fi
+				$sh_c "apt-get install -y -qq --no-install-recommends docker-ce$pkg_version >/dev/null"
 			)
 			echo_docker_as_nonroot
 			exit 0
 			;;
 		centos|fedora)
-			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/docker-ce.repo"
+			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+			if ! curl -Ifs "$yum_repo" > /dev/null; then
+				echo "Error: Unable to curl repository file $yum_repo, is it valid?"
+				exit 1
+			fi
 			if [ "$lsb_dist" = "fedora" ]; then
-				if [ "$dist_version" = "24" ]; then
-					echo
-					echo "Warning: Fedora 24 has reached EOL"
-					echo "         Support for Fedora 24 for this installation script will be removed on October 1, 2017"
-					echo
-					sleep 10
-				fi
-				if [ "$dist_version" -lt "24" ]; then
-					echo "Error: Only Fedora >=24 are supported"
-					exit 1
-				fi
 				pkg_manager="dnf"
 				config_manager="dnf config-manager"
 				enable_channel_flag="--set-enabled"
+				disable_channel_flag="--set-disabled"
 				pre_reqs="dnf-plugins-core"
+				pkg_suffix="fc$dist_version"
 			else
 				pkg_manager="yum"
 				config_manager="yum-config-manager"
 				enable_channel_flag="--enable"
+				disable_channel_flag="--disable"
 				pre_reqs="yum-utils"
+				pkg_suffix="el"
 			fi
 			(
 				if ! is_dry_run; then
@@ -425,13 +420,52 @@ do_install() {
 				$sh_c "$config_manager --add-repo $yum_repo"
 
 				if [ "$CHANNEL" != "stable" ]; then
+					$sh_c "$config_manager $disable_channel_flag docker-ce-*"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache"
-				$sh_c "$pkg_manager install -y -q docker-ce"
+			)
+			pkg_version=""
+			if [ -n "$VERSION" ]; then
+				if is_dry_run; then
+					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+				else
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g").*$pkg_suffix"
+					search_command="$pkg_manager list --showduplicates 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
+					pkg_version="$($sh_c "$search_command")"
+					echo "INFO: Searching repository for VERSION '$VERSION'"
+					echo "INFO: $search_command"
+					if [ -z "$pkg_version" ]; then
+						echo
+						echo "ERROR: '$VERSION' not found amongst $pkg_manager list results"
+						echo
+						exit 1
+					fi
+					search_command="$pkg_manager list --showduplicates 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
+					# It's okay for cli_pkg_version to be blank, since older versions don't support a cli package
+					cli_pkg_version="$($sh_c "$search_command" | cut -d':' -f 2)"
+					# Cut out the epoch and prefix with a '-'
+					pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
+				fi
+			fi
+			(
+				if ! is_dry_run; then
+					set -x
+				fi
+				# install the correct cli version first
+				if [ -n "$cli_pkg_version" ]; then
+					$sh_c "$pkg_manager install -y -q docker-ce-cli-$cli_pkg_version"
+				fi
+				$sh_c "$pkg_manager install -y -q docker-ce$pkg_version"
 			)
 			echo_docker_as_nonroot
 			exit 0
+			;;
+		*)
+			echo
+			echo "ERROR: Unsupported distribution '$lsb_dist'"
+			echo
+			exit 1
 			;;
 	esac
 	exit 1
@@ -440,3 +474,4 @@ do_install() {
 # wrapped up in a function so that we have some protection against only getting
 # half the file during "curl | sh"
 do_install
+

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -49,6 +49,12 @@
     owner: root
     group: root
     mode: 0644
+    
+- name: apt-get update
+  apt:
+    update_cache: yes
+    autoclean: yes
+    autoremove: yes
 
 - name: Install k8s {{ kubernetes_package_version }} Y'all
   apt:


### PR DESCRIPTION
Fixed error whilst using master branch with Raspbian Buster

## Description

Whilst bootstrapping to newly installed PI3s with Raspbian Buster installed I encountered the following errors:
* get-docker.sh is not working correctly, since the install script checks for the os id and raspbian buster is apparently not listed.
* after adding the kubernetes apt repository the apt-get update step was lost.

Solutions:
* Added the newest revision of the get-docker.sh from https://get.docker.com
* readded the `apt-get update` step from the 0.2.2 release

## Testing

I've tested the my changes with a PI cluster with 1 master and 2 worker nodes.
The bootstrapping went flawlessly and the kubernetes cluster is up and running.

## Issue Number
I did not open an issue for this fixes

