### PR TITLE
Rak8s pr ansible update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also, it's cheaper than a year of GKE. Plus, why not run Kubernetes in your home
     * The pi user is fine
     * Please change the pi user's password
 
-* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) 2.2 or higher
+* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) 2.7 or higher
 
 * [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) should be available on the system you intend to use to interact with the Kubernetes cluster.
     * If you are going to login to one of the Raspberry Pis to interact with the cluster `kubectl` is installed and configured by default on the master Kubernetes master.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also, it's cheaper than a year of GKE. Plus, why not run Kubernetes in your home
     * The pi user is fine
     * Please change the pi user's password
 
-* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) 2.7 or higher
+* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) 2.7.1 or higher
 
 * [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) should be available on the system you intend to use to interact with the Kubernetes cluster.
     * If you are going to login to one of the Raspberry Pis to interact with the cluster `kubectl` is installed and configured by default on the master Kubernetes master.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -24,7 +24,7 @@ kubernetes_version: "v1.17.0"
 # v1.9.6
 # v1.9.5
 
-docker_ce_version: "19.03.8~3-0~raspbian-buster"
+docker_ce_version: "19.03.8~3-0"
 # Available versions:
 # 18.05.0~ce~3-0~raspbian
 # 18.04.0~ce~3-0~raspbian

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,7 +1,7 @@
 token: udy29x.ugyyk3tumg27atmr
 podnet: 10.244.0.0/16
 
-kubernetes_package_version: "1.14.1-00"
+kubernetes_package_version: "1.17.0-00"
 # Available versions:
 # 1.13.1-00
 # 1.10.3-00
@@ -13,7 +13,7 @@ kubernetes_package_version: "1.14.1-00"
 # 1.9.6-00
 # 1.9.5-00
 
-kubernetes_version: "v1.14.1"
+kubernetes_version: "v1.17.0"
 # Available versions:
 # v1.10.3
 # v1.10.2
@@ -24,7 +24,7 @@ kubernetes_version: "v1.14.1"
 # v1.9.6
 # v1.9.5
 
-docker_ce_version: "18.06.2~ce~3-0~raspbian"
+docker_ce_version: "19.03.8~3-0~raspbian-buster"
 # Available versions:
 # 18.05.0~ce~3-0~raspbian
 # 18.04.0~ce~3-0~raspbian
@@ -39,4 +39,4 @@ flannel_version: "master"
 # v0.9.0
 # v0.8.0
 # v0.7.1
-# v0.7.0  
+# v0.7.0

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -22,9 +22,15 @@
 
 - name: "Remove pod logging"
   file:
-    path: /var/log/pods
+    path: "{{ item }}"
     state: absent
   become: True
+  loop:
+    - /etc/kubernetes
+    - /var/log/pods
+    - /var/log/containers
+    - /var/lib/kubelet
+
 
 - name: Reboot
   reboot:

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -27,10 +27,10 @@
   become: True
   loop:
     - /etc/kubernetes
-    - /var/log/pods
-    - /var/log/containers
     - /var/lib/kubelet
     - /var/lib/etcd
+    - /var/log/pods
+    - /var/log/containers
 
 - name: Reboot
   reboot:

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -30,8 +30,4 @@
     state: absent
   become: True
   loop:
-    - /etc/kubernetes
-    - /var/lib/etcd
-    - /var/lib/kubelet
-    - /var/log/containers
     - /var/log/pods

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -20,16 +20,18 @@
     autoremove: yes
     force: yes
 
+- name: Reboot
+  reboot:
+    reboot_timeout: 120
+
 - name: "Remove pod logging"
   file:
     path: "{{ item }}"
     state: absent
   become: True
   loop:
+    - /etc/kubernetes
     - /var/lib/etcd
-    - /var/log/pods
+    - /var/lib/kubelet
     - /var/log/containers
-
-- name: Reboot
-  reboot:
-    reboot_timeout: 120
+    - /var/log/pods

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -30,7 +30,7 @@
     - /var/log/pods
     - /var/log/containers
     - /var/lib/kubelet
-
+    - /var/lib/etcd
 
 - name: Reboot
   reboot:

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -20,10 +20,6 @@
     autoremove: yes
     force: yes
 
-- name: Reboot
-  reboot:
-    reboot_timeout: 120
-
 - name: "Remove pod logging"
   file:
     path: "{{ item }}"
@@ -31,3 +27,7 @@
   become: True
   loop:
     - /var/log/pods
+
+- name: Reboot
+  reboot:
+    reboot_timeout: 120

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -14,33 +14,18 @@
 
 - name: "apt-get purge packages"
   apt:
-    name: "{{ item }}"
+    name: ['kubelet', 'kubeadm', 'kubectl', 'docker-ce']
     state: absent
     purge: yes
     autoremove: yes
     force: yes
-  with_items:
-    - kubelet
-    - kubeadm
-    - kubectl
-    - docker-ce
 
 - name: "Remove pod logging"
-  shell: rm -rf /var/log/pods/* 
+  file:
+    path: /var/log/pods
+    state: absent
   become: True
 
 - name: Reboot
-  shell: sleep 2 && shutdown -r now "Ansible Reboot"
-  async: 1
-  poll: 0
-  ignore_errors: True
-
-- name: Wait for Reboot
-  local_action: wait_for
-  args:
-    host: "{{ inventory_hostname }}"
-    port: 22
-    delay: 15
-    timeout: 120
-  become: False
-
+  reboot:
+    reboot_timeout: 120

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -26,8 +26,6 @@
     state: absent
   become: True
   loop:
-    - /etc/kubernetes
-    - /var/lib/kubelet
     - /var/lib/etcd
     - /var/log/pods
     - /var/log/containers

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -54,22 +54,10 @@
     upgrade: full
 
 - name: python-apt dependency
-  shell: apt-get install -y python-apt
-  args:
-    warn: no
+  apt:
+    name: ['python-apt']
+    state: present
 
 - name: Reboot
-  shell: sleep 2 && shutdown -r now "Ansible Reboot"
-  async: 1
-  poll: 0
-  ignore_errors: True
-  when: cmdline or timezone or hostname is changed
-
-- name: Wait for Reboot
-  local_action: wait_for
-  args:
-    host: "{{ inventory_hostname }}"
-    port: 22
-    delay: 15
-    timeout: 120
-  become: False
+  reboot:
+    reboot_timeout: 120

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -48,10 +48,7 @@
     autoclean: yes
     autoremove: yes
     cache_valid_time: 86400
-
-- name: apt-get upgrade
-  apt:
-    upgrade: full
+    upgrade: yes
 
 - name: python-apt dependency
   apt:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -42,6 +42,14 @@
   tags:
     - boot
 
+# Doc: http://manpages.ubuntu.com/manpages/trusty/man8/dphys-swapfile.8.html
+- name: Disable Swap
+  lineinfile:
+    path: /etc/dphys-swapfile
+    regexp: '^CONF_SWAPSIZE='
+    line: CONF_SWAPSIZE=0
+  register: swap
+
 - name: apt-get update
   apt:
     update_cache: yes
@@ -58,4 +66,4 @@
 - name: Reboot
   reboot:
     reboot_timeout: 120
-  when: cmdline.changed or timezone.changed or hostname.changed
+  when: cmdline.changed or timezone.changed or hostname.changed or swap.changed

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -61,3 +61,4 @@
 - name: Reboot
   reboot:
     reboot_timeout: 120
+  when: cmdline or timezone or hostname is changed

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -58,4 +58,4 @@
 - name: Reboot
   reboot:
     reboot_timeout: 120
-  when: cmdline or timezone or hostname is changed
+  when: cmdline.changed or timezone.changed or hostname.changed

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -52,11 +52,11 @@
 
 - name: apt-get update
   apt:
-    update_cache: yes
-    autoclean: yes
-    autoremove: yes
+    update_cache: 'yes'
+    autoclean: 'yes'
+    autoremove: 'yes'
     cache_valid_time: 86400
-    upgrade: yes
+    upgrade: 'yes'
 
 - name: python-apt dependency
   apt:

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 # tasks file for kubeadm
 
-# https://gist.github.com/alexellis/fdbc90de7691a1b9edb545c17da2d975
-- name: Disable Swap
-  shell: dphys-swapfile swapoff && dphys-swapfile uninstall && update-rc.d dphys-swapfile remove
-  ignore_errors: True
-
 # Docker Convenience Script Can Only Be Run Once
 - name: Determine if docker is installed
   stat:
@@ -49,7 +44,7 @@
     owner: root
     group: root
     mode: 0644
-    
+
 - name: apt-get update
   apt:
     update_cache: yes

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -16,7 +16,7 @@
   when: docker_there.stat.exists == False
   register: docker_installed
 
-- name: Lock docker version to {{ docker_ce_version}}
+- name: Lock docker version to {{ docker_ce_version }}
   command: /usr/bin/apt-mark hold docker-ce
   when: docker_installed.changed
 
@@ -56,3 +56,12 @@
     name: "['kubelet={{ kubernetes_package_version }}', 'kubeadm={{ kubernetes_package_version }}','kubectl={{ kubernetes_package_version }}']"
     state: present
     force: yes
+  register: kubernetes_installed
+
+- name: Lock Kubernetes version to {{ kubernetes_package_version }}
+  command: "/usr/bin/apt-mark hold {{ item }}"
+  when: kubernetes_installed.changed
+  loop:
+  - kubelet
+  - kubeadm
+  - kubectl

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Pass bridged IPv4 traffic to iptables' chains
   sysctl:
     name: net.bridge.bridge-nf-call-iptables
-    value: 1
+    value: '1'
     state: present
 
 # https://kubernetes.io/docs/setup/independent/install-kubeadm/

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -38,9 +38,9 @@
     state: latest
 
 - name: Add Google Cloud Repo Key
-  shell: curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-  args:
-    warn: no
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    state: present
 
 - name: Add Kubernetes to Available apt Sources
   template:
@@ -58,10 +58,6 @@
 
 - name: Install k8s {{ kubernetes_package_version }} Y'all
   apt:
-    name: "{{ item }}={{ kubernetes_package_version }}"
+    name: "['kubelet={{ kubernetes_package_version }}', 'kubeadm={{ kubernetes_package_version }}','kubectl={{ kubernetes_package_version }}']"
     state: present
     force: yes
-  with_items:
-    - kubelet
-    - kubeadm
-    - kubectl

--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -35,7 +35,9 @@
 
 - name: Install Flannel (Networking)
   shell: "curl -sSL https://rawgit.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml | kubectl create -f -" 
-  warn: false
+  args:
+    warn: false
+
 
 - name: Poke kubelet
   systemd:

--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -35,6 +35,7 @@
 
 - name: Install Flannel (Networking)
   shell: "curl -sSL https://rawgit.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml | kubectl create -f -" 
+  warn: false
 
 - name: Poke kubelet
   systemd:

--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -26,7 +26,7 @@
     mode: 0755
     remote_src: yes
     backup: yes
-  when: kubeadm_init
+  when: kubeadm_init is succeeded
 
 - name: Join Kubernetes Cluster
   shell: kubeadm join --ignore-preflight-errors=all --token {{ token }} {{ groups['master'][0] }}:6443 --discovery-token-unsafe-skip-ca-verification
@@ -34,10 +34,9 @@
   register: kubeadm_join
 
 - name: Install Flannel (Networking)
-  shell: "curl -sSL https://rawgit.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml | kubectl create -f -" 
+  shell: "curl -sSL https://rawgit.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml | kubectl create -f -"
   args:
     warn: false
-
 
 - name: Poke kubelet
   systemd:

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -1,15 +1,13 @@
 - hosts: master
   tasks:
-    - name: apt-get update
-      apt:
-        update_cache: yes
-        autoclean: yes
-        autoremove: yes
-
     - name: Upgrade kubeadm
       apt:
         name: ['kubeadm']
         state: latest
+        force: yes
+        update_cache: yes
+        autoclean: yes
+        autoremove: yes
 
     - name: Determine latest stable version of Kubernetes
       shell: curl -sSL https://dl.k8s.io/release/stable.txt
@@ -41,6 +39,10 @@
       apt:
         name: ['kubelet', 'kubectl']
         state: latest
+        force: yes
+        update_cache: yes
+        autoclean: yes
+        autoremove: yes
       tags:
         - kubelet
         - kubectl

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -8,14 +8,14 @@
 
     - name: Upgrade kubeadm
       apt:
-        name: "{{ item }}"
+        name: ['kubeadm']
         state: latest
-      with_items:
-        - kubeadm
 
     - name: Determine latest stable version of Kubernetes
       shell: curl -sSL https://dl.k8s.io/release/stable.txt
       register: stable_ver
+      args:
+        warn: False
 
     - name: Upgrade cluster with kubeadm
       shell: "kubeadm upgrade apply -y {{ stable_ver.stdout }}"
@@ -39,11 +39,8 @@
   tasks:
     - name: Upgrade Y'all
       apt:
-        name: "{{ item }}"
+        name: ['kubelet', 'kubectl']
         state: latest
-      with_items:
-        - kubelet
-        - kubectl
       tags:
         - kubelet
         - kubectl

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -19,7 +19,7 @@
 
     - name: Upgrade cluster with kubeadm
       shell: "kubeadm upgrade apply -y {{ stable_ver.stdout }}"
-      async: 300
+      async: 600
       poll: 5
 
     - name: Cordon Hosts


### PR DESCRIPTION
<!-- Provide a general summary of changes in the Title above-->
Updated to resolve deprecation warnings, and replace shell module usage with appropriate module, if available.

Updated to Kubernetes v1.17, upgrading was not allowed from 1.14 to 1.18; 1.17 minimum was required.

Updated Docker version to reflect latest available in Raspbian Buster Lite.

<!-- Describe your change in detail -->

File: README.md
Description: Updated minimum required Ansible version to 2.7.1 for the reboot module.

File: group_vars/all.yml
Description: 
- Updated to 1.17.0 for Kube* packages.
- Updated docker-ce version to latest included with Raspbian Buster Lite.

File: roles/cleanup/tasks/main.yml
Description:
- Updated with_item to list per Ansible deprecation warning.
- Updated shell module to file module to delete pod logs.
- Updated reboot sequence to use reboot module.

File: roles/common/tasks/main.yml
Description: 
- Combined apt update and upgrade tasks.
- Added disabled swap, reboot to apply changes.
- Update shell module to apt module for package install.
- Updated reboot sequence to use reboot module.
- Updated when: conditional on reboot; was not working with Ansible 2.7+

File: roles/kubeadm/tasks/main.yml
Description: 
- Removed disable swap, it was not persisting through a reboot. Moved to common/tasks/main.yml
- Updated shell module to apt_key module.
- Updated with_item to list per Ansible deprecation warning.
- Added package locking to Kubernetes Packages.  This makes the common and kubeadm roles immutable.


File: roles/master/tasks/main.yml
Description: 
- Added warn: false to shell command

File: upgrade.yml
Description: 
- Updated with_item to list per Ansible deprecation warning.
- Added warn: false to shell command
- Updated timeout due to not completing in time failures
- Updated with_item to list per Ansible deprecation warning.

<!-- How have you tested the changes you made? -->
A cluster was created, destroyed, created, upgraded, and destroyed locally in my network.

<!-- Describe your tests in detail and the environment -->
Using 3x rpi 3 B with Raspbian Buster Lite, release date 2020-02-13
1. ansible-playbook cluster.yml
2. ansible-playbook cleanup.yml
3. ansible-playbook cluster.yml
4. ansible-playbook upgrade.yml
5. ansible-playbook cleanup.yml
